### PR TITLE
Fix issue 1057 (Auto set back image from barcode scan)

### DIFF
--- a/app/src/main/java/protect/card_locker/BarcodeImageWriterTask.java
+++ b/app/src/main/java/protect/card_locker/BarcodeImageWriterTask.java
@@ -265,6 +265,9 @@ public class BarcodeImageWriterTask implements CompatCallable<Bitmap> {
 
             if (isSuccesful) {
                 imageView.setColorFilter(null);
+                //set back image to the result (in setImage..(result)) ??
+                LoyaltyCardEditActivity.mBackImageUnsaved = true;
+                LoyaltyCardEditActivity.setCardImage(LoyaltyCardEditActivity.cardImageBack, Utils.resizeBitmap(result, Utils.BITMAP_SIZE_BIG), true);
             } else {
                 imageView.setColorFilter(Color.LTGRAY, PorterDuff.Mode.LIGHTEN);
             }

--- a/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
+++ b/app/src/main/java/protect/card_locker/LoyaltyCardEditActivity.java
@@ -138,7 +138,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
     View cardImageFrontHolder;
     View cardImageBackHolder;
     ImageView cardImageFront;
-    ImageView cardImageBack;
+    static ImageView cardImageBack;
 
     Button enterButton;
 
@@ -180,7 +180,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
     UCrop.Options mCropperOptions;
 
     boolean mFrontImageUnsaved = false;
-    boolean mBackImageUnsaved = false;
+    static boolean mBackImageUnsaved = false;
     boolean mIconUnsaved = false;
 
     boolean mFrontImageRemoved = false;
@@ -946,7 +946,7 @@ public class LoyaltyCardEditActivity extends CatimaAppCompatActivity {
         }
     }
 
-    protected void setCardImage(ImageView imageView, Bitmap bitmap, boolean applyFallback) {
+    protected static void setCardImage(ImageView imageView, Bitmap bitmap, boolean applyFallback) {
         imageView.setTag(bitmap);
 
         if (bitmap != null) {


### PR DESCRIPTION
Barcode scan from imported picture now auto sets to back image
The original issue said it should set the front as well, which makes no sense bc that would be impossible
So I focused on just getting the back done, and it works.